### PR TITLE
Setup heroku deploys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - *attach_workspace
       - run:
           name: Build
-          command: bundle exec rake build
+          command: bundle exec rake assets:precompile
       - *persist_workspace
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,20 +62,6 @@ jobs:
           command: bundle exec rake build
       - *persist_workspace
 
-  deploy:
-    <<: *defaults
-    steps:
-      - *attach_workspace
-      - run:
-          name: Setup git config
-          command: |
-            touch ~/.gitconfig
-            git config --global user.email $GIT_EMAIL
-            git config --global user.name $GIT_USERNAME
-      - run:
-          name: Publish to gh-pages
-          command: bundle exec rake publish
-
 workflows:
   version: 2
   default:
@@ -84,9 +70,3 @@ workflows:
       - build:
           requires:
             - install
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-bigtest.js.org

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+gem 'puma'
+gem 'rake'
+gem 'rack-contrib'
+
 gem 'middleman', '~> 4.2'
 gem 'middleman-autoprefixer', '~> 2.7'
 gem 'middleman-gh-pages', '~> 0.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ gem 'rack-contrib'
 
 gem 'middleman', '~> 4.2'
 gem 'middleman-autoprefixer', '~> 2.7'
-gem 'middleman-gh-pages', '~> 0.3.1'
 gem 'middleman-livereload', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,8 +78,6 @@ GEM
       servolux
       tilt (~> 2.0)
       uglifier (~> 3.0)
-    middleman-gh-pages (0.3.1)
-      rake (> 0.9.3)
     middleman-livereload (3.4.6)
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
@@ -120,7 +118,6 @@ PLATFORMS
 DEPENDENCIES
   middleman (~> 4.2)
   middleman-autoprefixer (~> 2.7)
-  middleman-gh-pages (~> 0.3.1)
   middleman-livereload (~> 3.4)
   puma
   rack-contrib

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,10 @@ GEM
       activesupport (>= 3.1)
     parallel (1.12.1)
     public_suffix (3.0.2)
+    puma (3.11.4)
     rack (2.0.4)
+    rack-contrib (2.0.1)
+      rack (~> 2.0)
     rack-livereload (0.3.17)
       rack
     rake (12.3.1)
@@ -119,6 +122,9 @@ DEPENDENCIES
   middleman-autoprefixer (~> 2.7)
   middleman-gh-pages (~> 0.3.1)
   middleman-livereload (~> 3.4)
+  puma
+  rack-contrib
+  rake
 
 BUNDLED WITH
    1.16.1

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,30 @@
+require "rack"
+require "rack/contrib/try_static"
+
+# Enable proper HEAD responses
+use Rack::Head
+
+# Add basic auth if configured
+if ENV["HTTP_USER"] && ENV["HTTP_PASSWORD"]
+  use Rack::Auth::Basic, "Restricted Area" do |username, password|
+    [username, password] == [ENV["HTTP_USER"], ENV["HTTP_PASSWORD"]]
+  end
+end
+
+# Attempt to serve static HTML files
+use Rack::TryStatic,
+    :root => "build",
+    :urls => %w[/],
+    :try => ['.html', 'index.html', '/index.html']
+
+# Serve a 404 page if all else fails
+run lambda { |env|
+  [
+    404,
+    {
+      "Content-Type" => "text/html",
+      "Cache-Control" => "public, max-age=60"
+    },
+    File.open("build/404/index.html", File::RDONLY)
+  ]
+}

--- a/rakefile
+++ b/rakefile
@@ -1,1 +1,5 @@
-require 'middleman-gh-pages'
+namespace :assets do
+  task :precompile do
+    sh "yarn && middleman build"
+  end
+end


### PR DESCRIPTION
## Purpose

To deploy the BigTest docs site to heroku. This is because deploying to gh-pages was proving to be more difficult than worth & by using heroku we enable the use of review apps, which are dope. 

When CI on master passes heroku will auto deploy the docs for us. 